### PR TITLE
Change to set python path to configured one properly

### DIFF
--- a/setup/ibus-setup-array.in
+++ b/setup/ibus-setup-array.in
@@ -19,5 +19,5 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  
-exec python @prefix@/share/ibus-array/setup/main.py $@
+exec @PYTHON@ @prefix@/share/ibus-array/setup/main.py $@
 


### PR DESCRIPTION
It is required for the case using phthon with version suffix (ex. python2).