### PR TITLE
Specify the setup path in the IBus component XML

### DIFF
--- a/src/array.xml.in.in
+++ b/src/array.xml.in.in
@@ -20,6 +20,7 @@
 			<layout>us</layout>
 			<longname>Array</longname>
 			<description>Array 30 Input Method</description>
+			<setup>${libexecdir}/ibus-setup-array</setup>
 			<rank>99</rank>
 		</engine>
 	</engines>


### PR DESCRIPTION
It's always good to specify the setup path explicitly. If it's not specified,
ibus-setup finds ibus-setup-array in libexec, assuming ibus-array uses the same
libexec as ibus. Depending on this fallback makes it difficult to migrate from
FHS 2.0 (/usr/lib) to FHS 3.0 (/usr/libexec).