### PR TITLE
Fix incompatible-pointer-types warning in engine.c

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -69,7 +69,7 @@ static void ibus_array_engine_page_down (IBusEngine *engine);
 static void ibus_array_engine_cursor_up (IBusEngine *engine);
 static void ibus_array_engine_cursor_down (IBusEngine *engine);
 
-static void ibus_array_engine_property_activate (IBusEngine *engine, const gchar *prop_name, gint prop_state);
+static void ibus_array_engine_property_activate (IBusEngine *engine, const gchar *prop_name, guint prop_state);
 static void ibus_array_engine_property_show (IBusEngine *engine, const gchar *prop_name);
 static void ibus_array_engine_property_hide (IBusEngine *engine, const gchar *prop_name);
 
@@ -639,7 +639,7 @@ static void ibus_array_engine_show_special_code_for_char (IBusArrayEngine *array
     array_release_candidates(candidates);
 }
 
-static void ibus_array_engine_property_activate (IBusEngine *engine, const gchar *prop_name, gint prop_state) {
+static void ibus_array_engine_property_activate (IBusEngine *engine, const gchar *prop_name, guint prop_state) {
     if (g_strcmp0(prop_name, "setup") == 0) {
         GError *error = NULL;
         gchar *argv[2] = { NULL, };


### PR DESCRIPTION
The warning message was:
```
engine.c:179:37: warning: assignment to 
  ‘void (*)(IBusEngine *, const gchar *, guint)’ {aka ‘void (*)(struct _IBusEngine *, const char *, unsigned int)’} from incompatible pointer type 
  ‘void (*)(IBusEngine *, const gchar *, gint)’ {aka ‘void (*)(struct _IBusEngine *, const char *, int)’} [-Wincompatible-pointer-types]
```
