### PR TITLE
Fix Gtk deprecation warnings for setup dialog

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -42,16 +42,18 @@ class Setup:
     def __create_ui(self):
         gettext.bindtextdomain("ibus-array")
         gettext.textdomain("ibus-array")
-        self.__window = Gtk.Dialog(_('ibus-array setup'), None, 
-                                    Gtk.DialogFlags.MODAL, 
-                                    (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, 
-                                     Gtk.STOCK_OK, Gtk.ResponseType.OK)
-                                  )
+        self.__window = Gtk.Dialog(
+            title=_('ibus-array setup'),
+            parent=None,
+            modal=True)
+        self.__window.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OK, Gtk.ResponseType.OK)
         icon_file = os.path.join(config.datadir, "ibus-array", "icons", "ibus-array.png")
         self.__window.set_icon_from_file(icon_file)
-        self.__special_notify_button = Gtk.CheckButton(_("Special Code Notification"))
+        self.__special_notify_button = Gtk.CheckButton(label=_("Special Code Notification"))
         self.__window.vbox.pack_start(self.__special_notify_button, True, True, 10)
-        self.__special_only_button = Gtk.CheckButton(_("Special Code Only Mode"))
+        self.__special_only_button = Gtk.CheckButton(label=_("Special Code Only Mode"))
         self.__window.vbox.pack_start(self.__special_only_button, True, True ,10)
 
         current_special_mode = self.__read("SpecialOnly", False)


### PR DESCRIPTION
The warnings were:
```
/usr/share/ibus-array/setup/main.py:45: PyGTKDeprecationWarning: The "buttons" argument must be a Gtk.ButtonsType enum value. Please use the "add_buttons" method for adding buttons. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.__window = Gtk.Dialog(_('ibus-array setup'), None,
/usr/share/ibus-array/setup/main.py:45: PyGTKDeprecationWarning: The "flags" argument for dialog construction is deprecated. Please use initializer keywords: modal=True and/or destroy_with_parent=True. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.__window = Gtk.Dialog(_('ibus-array setup'), None,
/usr/share/ibus-array/setup/main.py:52: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.__special_notify_button = Gtk.CheckButton(_("Special Code Notification"))
/usr/share/ibus-array/setup/main.py:54: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self.__special_only_button = Gtk.CheckButton(_("Special Code Only Mode"))
```