### PR TITLE
Update array_input_key_is_not_special query

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -245,7 +245,7 @@ array_input_key_is_not_special(ArrayContext* context,
     gchar *special_keys = NULL;
 
     retcode = sqlite3_prepare_v2(context->conn, 
-            "SELECT keys FROM special WHERE ch=?", -1, &stmt, NULL);
+            "SELECT keys FROM main WHERE cat='2' AND ch=?", -1, &stmt, NULL);
 
     if (retcode == SQLITE_OK) {
         sqlite3_bind_text(stmt, 1, ch, -1, SQLITE_TRANSIENT);

--- a/src/engine.c
+++ b/src/engine.c
@@ -457,6 +457,8 @@ static gboolean  ibus_array_engine_process_key_event (IBusEngine *engine, guint 
             return TRUE;
 
     case IBUS_Escape:
+        if (arrayeng->preedit->len == 0)
+            return FALSE;
         ibus_array_engine_reset((IBusEngine*)arrayeng);
         return TRUE;        
 


### PR DESCRIPTION
Current database file array.db does not have special table.
I update the query string to let function work.